### PR TITLE
fuse-auditing performance improvement for traceData fetching

### DIFF
--- a/Fuse/qlack2-fuse-auditing/qlack2-fuse-auditing-api/src/main/java/com/eurodyn/qlack2/fuse/auditing/api/AuditLoggingService.java
+++ b/Fuse/qlack2-fuse-auditing/qlack2-fuse-auditing-api/src/main/java/com/eurodyn/qlack2/fuse/auditing/api/AuditLoggingService.java
@@ -132,6 +132,13 @@ public interface AuditLoggingService {
 	 */
 	public List<AuditLogDTO> listAuditLogs(List<SearchDTO> searchList,
 			Date startDate, Date endDate, List<SortDTO> sortList,
+			PagingParams pagingParams, boolean fetchTraceData);
+
+	/**
+	 * Convenience method for the {@link #listAuditLogs(List, Date, Date, List, PagingParams, boolean)}, with {@code fetchTraceData} set to true.
+	 */
+	public List<AuditLogDTO> listAuditLogs(List<SearchDTO> searchList,
+			Date startDate, Date endDate, List<SortDTO> sortList,
 			PagingParams pagingParams);
 
 	/**

--- a/Fuse/qlack2-fuse-auditing/qlack2-fuse-auditing-impl/src/main/java/com/eurodyn/qlack2/fuse/auditing/impl/model/Audit.java
+++ b/Fuse/qlack2-fuse-auditing/qlack2-fuse-auditing-impl/src/main/java/com/eurodyn/qlack2/fuse/auditing/impl/model/Audit.java
@@ -20,6 +20,7 @@ import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 @Entity
@@ -31,7 +32,7 @@ public class Audit {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "level_id")
 	private AuditLevel levelId;
-	@ManyToOne(fetch = FetchType.LAZY)
+	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "trace_id")
 	private AuditTrace traceId;
 	@Column(name = "prin_session_id")

--- a/Fuse/qlack2-fuse-auditing/qlack2-fuse-auditing-impl/src/main/java/com/eurodyn/qlack2/fuse/auditing/impl/util/ConverterUtil.java
+++ b/Fuse/qlack2-fuse-auditing/qlack2-fuse-auditing-impl/src/main/java/com/eurodyn/qlack2/fuse/auditing/impl/util/ConverterUtil.java
@@ -117,13 +117,13 @@ public final class ConverterUtil {
 	 * @param log
 	 * @return AuditLogDTO
 	 */
-	public static AuditLogDTO convertToAuditLogDTO(Audit log) {
+	public static AuditLogDTO convertToAuditLogDTO(Audit log, boolean setTraceData) {
 		LOGGER.log(Level.FINEST,
 				"Converting audit level model to audit ''{0}''.", log);
 		AuditLogDTO alLog = null;
 		if (null != log) {
 			alLog = new AuditLogDTO();
-			if (null != log.getTraceId()) {
+			if (setTraceData && null != log.getTraceId()) {
 				alLog.setTraceData(log.getTraceId().getTraceData());
 			}
 			if (null != log.getCreatedOn()) {
@@ -142,14 +142,19 @@ public final class ConverterUtil {
 		}
 		return alLog;
 	}
+	
+	public static AuditLogDTO convertToAuditLogDTO(Audit log) {
+		return ConverterUtil.convertToAuditLogDTO(log, true);
+	}
 
 	/**
 	 * Get AuditLogDTO List from AlAudit List
 	 *
 	 * @param list
+	 * @param setTraceData Set to false if trace data should be ignored
 	 * @return List
 	 */
-	public static List<AuditLogDTO> convertToAuditLogList(List<Audit> list) {
+	public static List<AuditLogDTO> convertToAuditLogList(List<Audit> list, boolean setTraceData) {
 		LOGGER.log(Level.FINEST,
 				"Converting audit log model list to audit log DTO list.");
 		if (list == null) {
@@ -158,9 +163,13 @@ public final class ConverterUtil {
 		List<AuditLogDTO> aList = new ArrayList<>(list.size());
 		for (int i = 0; i < list.size(); i++) {
 			Audit auditLog = list.get(i);
-			aList.add(ConverterUtil.convertToAuditLogDTO(auditLog));
+			aList.add(ConverterUtil.convertToAuditLogDTO(auditLog, setTraceData));
 		}
 		return aList;
+	}
+	
+	public static List<AuditLogDTO> convertToAuditLogList(List<Audit> list) {
+		return ConverterUtil.convertToAuditLogList(list, true);
 	}
 
 	/**


### PR DESCRIPTION
Function listAuditLogs(..) now fetches traceData using a sql join,
instead of issuing multiple select statements later.

An extra boolean argument fetchTraceData was introduced, so the client
may opt not to fetch the associated traceData at all.